### PR TITLE
修复当关系使用foreign_key选项时出错，增加destroy时的expire【修正】

### DIFF
--- a/lib/cacheable.rb
+++ b/lib/cacheable.rb
@@ -11,7 +11,7 @@ module Cacheable
           self.cached_key = true
 
           class_eval <<-EOF
-            after_commit :expire_key_cache, :on => :update
+            after_commit :expire_key_cache, :in => [:update,:destroy]
 
             def self.find_cached(id)
               Rails.cache.fetch "#{name.tableize}/" + id.to_i.to_s do
@@ -25,7 +25,7 @@ module Cacheable
           self.cached_indices = attributes.inject({}) { |indices, attribute| indices[attribute] = {} }
 
           class_eval <<-EOF
-            after_commit :expire_attribute_cache, :on => :update
+            after_commit :expire_attribute_cache, :in => [:update,:destroy]
           EOF
 
           attributes.each do |attribute|
@@ -45,7 +45,7 @@ module Cacheable
           self.cached_methods = methods
 
           class_eval <<-EOF
-            after_commit :expire_method_cache, :on => :update
+            after_commit :expire_method_cache, :in => [:update,:destroy]
           EOF
 
           methods.each do |meth|

--- a/lib/cacheable.rb
+++ b/lib/cacheable.rb
@@ -142,10 +142,11 @@ module Cacheable
   end
 
   def belong_association_cache_key(name, polymorphic=nil)
+    foreign_key = association(name.to_sym).options[:foreign_key] || "#{name}_id"
     if polymorphic
-      "#{self.send("#{name}_type").tableize}/#{self.send("#{name}_id")}"
+      "#{self.send("#{name}_type").tableize}/#{self.send(foreign_key)}"
     else
-      "#{name.tableize}/#{self.send(name + "_id")}"
+      "#{name.tableize}/#{self.send(foreign_key)}"
     end
   end
 

--- a/spec/cacheable_spec.rb
+++ b/spec/cacheable_spec.rb
@@ -165,6 +165,14 @@ describe Cacheable do
       cache.data["users/#{@user.id}/association/posts"].should be_nil
     end
 
+
+    it "should delete has_many with_association cache on destroy" do
+      @user.cached_posts
+      cache.data["users/#{@user.id}/association/posts"].should_not be_nil
+      @post1.destroy
+      cache.data["users/#{@user.id}/association/posts"].should be_nil
+    end
+
     it "should delete has_many with polymorphic with_association cache" do
       @post1.cached_comments
       cache.data["posts/#{@post1.id}/association/comments"].should_not be_nil
@@ -172,10 +180,24 @@ describe Cacheable do
       cache.data["posts/#{@post1.id}/association/comments"].should be_nil
     end
 
+    it "should delete has_many with polymorphic with_association cache on destroy" do
+      @post1.cached_comments
+      cache.data["posts/#{@post1.id}/association/comments"].should_not be_nil
+      @comment1.destroy
+      cache.data["posts/#{@post1.id}/association/comments"].should be_nil
+    end
+
     it "should delete has_one with_association cache" do
       @user.cached_account
       cache.data["users/#{@user.id}/association/account"].should_not be_nil
       @account.save
+      cache.data["users/#{@user.id}/association/account"].should be_nil
+    end
+
+    it "should delete has_one with_association cache on destroy" do
+      @user.cached_account
+      cache.data["users/#{@user.id}/association/account"].should_not be_nil
+      @account.destroy
       cache.data["users/#{@user.id}/association/account"].should be_nil
     end
   end

--- a/spec/models/account.rb
+++ b/spec/models/account.rb
@@ -1,3 +1,3 @@
 class Account < ActiveRecord::Base
-  belongs_to :user
+  belongs_to :user,foreign_key: "u_id"
 end

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
   include Cacheable
 
   has_many :posts
-  has_one :account
+  has_one :account,foreign_key: "u_id"
 
   model_cache do
     with_key

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,7 +66,7 @@ RSpec.configure do |config|
       end
 
       create_table :accounts do |t|
-        t.integer :user_id
+        t.integer :u_id
       end
 
       create_table :posts do |t|


### PR DESCRIPTION
请问那个文件是干什么的。。？

另外`after_commit :func,on: []`
很惊讶..这种写法不行，on的value会直接传到一个eval的字符串里。
但是我偶然写错成in竟然可以用。。
