### PR TITLE
added functionality to find all by an attribute

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,2 +1,3 @@
+rvm use 1.9.3
 rvm_gemset_create_on_use_flag=1
 rvm gemset use cacheable

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,3 +1,2 @@
-rvm use 1.9.3
 rvm_gemset_create_on_use_flag=1
 rvm gemset use cacheable

--- a/spec/cacheable_spec.rb
+++ b/spec/cacheable_spec.rb
@@ -51,7 +51,30 @@ describe Cacheable do
       new_user = User.create(:login => "user space")
       User.find_cached_by_login("user space").should == new_user
     end
+
+    it "should handle fixed numbers" do
+      Post.find_cached_by_user_id(@user.id).should == @post1
+      Rails.cache.read("posts/attribute/user_id/#{@user.id}").should == @post1
+    end
+
+    context "find_all" do
+      it "should not cache Post.find_all_by_user_id" do
+        Rails.cache.read("posts/attribute/user_id/all/#{@user.id}").should be_nil
+      end
+
+      it "should cache by Post.find_cached_all_by_user_id" do
+        Post.find_cached_all_by_user_id(@user.id).should == [@post1, @post2]
+        Rails.cache.read("posts/attribute/user_id/all/#{@user.id}").should == [@post1, @post2]
+      end
+
+      it "should get cached by Post.find_cached_all_by_user_id multiple times" do
+        Post.find_cached_all_by_user_id(@user.id)
+        Post.find_cached_all_by_user_id(@user.id).should == [@post1, @post2]
+      end
+
+    end
   end
+
 
   context "with_method" do
     it "should not cache User.last_post" do

--- a/spec/models/post.rb
+++ b/spec/models/post.rb
@@ -6,6 +6,7 @@ class Post < ActiveRecord::Base
 
   model_cache do
     with_key
+    with_attribute :user_id
     with_association :user, :comments
   end
 end


### PR DESCRIPTION
Added to the with_attribute method a second set of methods so that you can do find_cached_all_by_attribute.  A better name might be find_all_cached_by_attribute but you seem to be keeping it consistent to always start with find_cached.  

Also wrote in specs to test it and found that the with_attribute methods didn't like using fix numbers as cache keys - converting them to strings before the URI escape fixed that.
