### PR TITLE
Expire all in expire model cache

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,3 +1,2 @@
-rvm use 1.9.3
 rvm_gemset_create_on_use_flag=1
 rvm gemset use cacheable

--- a/lib/cacheable.rb
+++ b/lib/cacheable.rb
@@ -29,7 +29,6 @@ module Cacheable
           class_eval <<-EOF
             after_commit :expire_attribute_cache, :on => :update
             after_commit :expire_all_attribute_cache, :on => :update
-
           EOF
 
           attributes.each do |attribute|
@@ -125,6 +124,7 @@ module Cacheable
   def expire_model_cache
     expire_key_cache if self.class.cached_key
     expire_attribute_cache if self.class.cached_indices.present?
+    expire_all_attribute_cache if self.class.cached_indices.present?
     expire_method_cache if self.class.cached_methods.present?
   end
 


### PR DESCRIPTION
For completeness.  Expire the find all attribute methods in expire_model_cache
