### PR TITLE
Support has_many -> through associations

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,3 +1,2 @@
-rvm use 1.9.3
 rvm_gemset_create_on_use_flag=1
 rvm gemset use cacheable

--- a/lib/cacheable.rb
+++ b/lib/cacheable.rb
@@ -89,9 +89,7 @@ module Cacheable
               reverse_association = association.klass.reflect_on_all_associations(:belongs_to).find { |reverse_association|
                 reverse_association.options[:polymorphic] ? reverse_association.name == as : reverse_association.klass == self
               }
-              # reverse_association = association.klass.reflect_on_all_associations(:belongs_to).find { |reverse_association|
-              #   reverse_association.options[:polymorphic] ? reverse_association.name == association.options[:as] : reverse_association.klass == self
-              # }
+
               association.klass.class_eval <<-EOF
                 after_commit :expire_#{association_name}_cache
 

--- a/lib/cacheable.rb
+++ b/lib/cacheable.rb
@@ -85,9 +85,13 @@ module Cacheable
                 end
               EOF
             else
+              as = association.options[:through] ? association.source_reflection.options[:as] : association.options[:as]
               reverse_association = association.klass.reflect_on_all_associations(:belongs_to).find { |reverse_association|
-                reverse_association.options[:polymorphic] ? reverse_association.name == association.options[:as] : reverse_association.klass == self
+                reverse_association.options[:polymorphic] ? reverse_association.name == as : reverse_association.klass == self
               }
+              # reverse_association = association.klass.reflect_on_all_associations(:belongs_to).find { |reverse_association|
+              #   reverse_association.options[:polymorphic] ? reverse_association.name == association.options[:as] : reverse_association.klass == self
+              # }
               association.klass.class_eval <<-EOF
                 after_commit :expire_#{association_name}_cache
 

--- a/spec/cacheable_spec.rb
+++ b/spec/cacheable_spec.rb
@@ -8,6 +8,8 @@ describe Cacheable do
     @account = @user.create_account
     @post1 = @user.posts.create(:title => 'post1')
     @post2 = @user.posts.create(:title => 'post2')
+    @image1 = @post1.images.create
+    @image2 = @post1.images.create
     @comment1 = @post1.comments.create
     @comment2 = @post1.comments.create
   end
@@ -160,6 +162,22 @@ describe Cacheable do
       it "should cache User#posts multiple times" do
         @user.cached_account
         @user.cached_account.should == @account
+      end
+    end
+
+    context "has_many through" do
+      it "should not cache associations" do
+        Rails.cache.read("users/#{@user.id}/association/images").should be_nil
+      end
+
+      it "should cache User#images" do
+        @user.cached_images.should == [@image1, @image2]
+        Rails.cache.read("users/#{@user.id}/association/images").should == [@image1, @image2]
+      end
+
+      it "should cache User#images multiple times" do
+        @user.cached_images
+        @user.cached_images.should == [@image1, @image2]
       end
     end
   end

--- a/spec/models/image.rb
+++ b/spec/models/image.rb
@@ -1,0 +1,5 @@
+class Image < ActiveRecord::Base
+
+  belongs_to :viewable, :polymorphic => true
+
+end

--- a/spec/models/post.rb
+++ b/spec/models/post.rb
@@ -4,9 +4,11 @@ class Post < ActiveRecord::Base
   belongs_to :user
   has_many :comments, :as => :commentable
 
+  has_many :images, :as => :viewable
+
   model_cache do
     with_key
     with_attribute :user_id
-    with_association :user, :comments
+    with_association :user, :comments, :images
   end
 end

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -3,12 +3,13 @@ class User < ActiveRecord::Base
 
   has_many :posts
   has_one :account
+  has_many :images, through: :posts
 
   model_cache do
     with_key
     with_attribute :login
     with_method :last_post
-    with_association :posts, :account
+    with_association :posts, :account, :images
   end
 
   def last_post

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,11 @@ RSpec.configure do |config|
         t.integer :commentable_id
         t.string :commentable_type
       end
+
+      create_table :images do |t|
+        t.integer :viewable_id
+        t.string :viewable_type
+      end
     end
   end
 


### PR DESCRIPTION
I found that has_many through associations weren't working.

This looks for the source_reflection on any associations that are through another model and sets that as the one to compare to in order to get the reverse_association.

Let me know what you think.
