### PR TITLE
Fix has many through expiration

### DIFF
--- a/spec/cacheable_spec.rb
+++ b/spec/cacheable_spec.rb
@@ -179,7 +179,17 @@ describe Cacheable do
         @user.cached_images
         @user.cached_images.should == [@image1, @image2]
       end
+
+      context "expiry" do
+        it "should have the correct collection" do
+          @image3 = @post1.images.create
+          Rails.cache.read("users/#{@user.id}/association/images").should be_nil
+          @user.cached_images.should == [@image1, @image2, @image3]
+          Rails.cache.read("users/#{@user.id}/association/images").should == [@image1, @image2, @image3]
+        end
+      end
     end
+
   end
 
   context "expire_model_cache" do
@@ -216,6 +226,13 @@ describe Cacheable do
       Rails.cache.read("posts/#{@post1.id}/association/comments").should_not be_nil
       @comment1.save
       Rails.cache.read("posts/#{@post1.id}/association/comments").should be_nil
+    end
+
+    it "should delete has_many through with_association cache" do
+      @user.cached_images
+      Rails.cache.read("users/#{@user.id}/association/images").should_not be_nil
+      @image2.save
+      Rails.cache.read("users/#{@user.id}/association/images").should be_nil
     end
 
     it "should delete has_one with_association cache" do


### PR DESCRIPTION
This got kind of ugly.  

The wrong key was being deleted for a has_many association.  It wasn't making the jump back through the 'through' association to eliminate the key associated with the original model.

This works but I'm worried about the reflection on the through association on line 90.  I believe since it's the middle association between the two that it should always be the only one but I'm not 100% sure.

Also, the code got really ugly in order to interpolate the right values into the expire method.  I haven't been metaprogramming for very long so I would welcome recommendations on DRYing it up
