### PR TITLE
Callback bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    simple_cacheable (1.3.2)
+    simple_cacheable (1.3.3)
       rails (>= 3.0.0)
 
 GEM
@@ -37,7 +37,6 @@ GEM
       tzinfo (~> 0.3.37)
     arel (4.0.0)
     atomic (1.1.10)
-    atomic (1.1.10-java)
     builder (3.1.4)
     diff-lcs (1.1.3)
     erubis (2.7.0)

--- a/lib/cacheable/types/association_cache.rb
+++ b/lib/cacheable/types/association_cache.rb
@@ -36,7 +36,9 @@ module Cacheable
                     # cached_viewable.expire_association_cache
                     send("cached_#{reverse_association.name}").expire_association_cache(association_name)
                   else
-                    send(reverse_association.name).send(reverse_through_association.name).expire_association_cache(association_name)
+                    if send(reverse_association.name)
+                      send(reverse_association.name).send(reverse_through_association.name).expire_association_cache(association_name)
+                    end
                   end
                 end
               end

--- a/spec/cacheable/types/association_cache_spec.rb
+++ b/spec/cacheable/types/association_cache_spec.rb
@@ -163,4 +163,18 @@ describe Cacheable do
 
   end
 
+  describe "after_commit bug" do
+    it "normal" do
+      @image1.expects(:do_something).once
+      @image1.save
+    end
+
+    it "new image fails without association" do
+      image = Image.new
+      image.expects(:do_something).once
+      image.save
+    end
+
+  end
+
 end

--- a/spec/models/image.rb
+++ b/spec/models/image.rb
@@ -2,4 +2,9 @@ class Image < ActiveRecord::Base
 
   belongs_to :viewable, :polymorphic => true
 
+  after_commit :do_something
+
+  def do_something
+    puts "hi"
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,7 @@ RSpec.configure do |config|
       create_table :images do |t|
         t.integer :viewable_id
         t.string :viewable_type
+        t.string :name
       end
 
       create_table :tags do |t|


### PR DESCRIPTION
What was happening here is the Image model would raise an error when trying to expire the associations it had if the image wasn't currently associated with anything.  This would in turn break all further after_commit callbacks.  The solution is to check whether the reverse_association exists before calling any further methods on it.
