### PR TITLE
Association belongs bug

### DIFF
--- a/lib/cacheable.rb
+++ b/lib/cacheable.rb
@@ -26,3 +26,11 @@ module Cacheable
   end
 
 end
+
+
+# class NilClass
+#   def expire_association_cache(name)
+#     byebug
+#     a = 1
+#   end
+# end

--- a/lib/cacheable.rb
+++ b/lib/cacheable.rb
@@ -26,11 +26,3 @@ module Cacheable
   end
 
 end
-
-
-# class NilClass
-#   def expire_association_cache(name)
-#     byebug
-#     a = 1
-#   end
-# end

--- a/lib/cacheable/types/association_cache.rb
+++ b/lib/cacheable/types/association_cache.rb
@@ -34,10 +34,13 @@ module Cacheable
                 after_commit "expire_#{association_name}_cache".to_sym
 
                 define_method("expire_#{association_name}_cache") do
+
                   if respond_to? "expire_#{reverse_association.name}_cache".to_sym
-                    send("cached_#{reverse_association.name}").expire_association_cache(association_name)
-                  else
-                    if send(reverse_association.name) && send(reverse_association.name).respond_to?(reverse_through_association.name)
+                    unless send("cached_#{reverse_association.name}").nil?
+                      send("cached_#{reverse_association.name}").expire_association_cache(association_name)
+                    end
+                  elsif !send(reverse_association.name).nil?
+                    if send(reverse_association.name).respond_to?(reverse_through_association.name)
                       send(reverse_association.name).send(reverse_through_association.name).expire_association_cache(association_name)
                     end
                   end
@@ -55,9 +58,11 @@ module Cacheable
 
                 define_method "expire_#{association_name}_cache" do
                   if respond_to? "cached_#{reverse_association.name}".to_sym
-                    # cached_viewable.expire_association_cache
-                    send("cached_#{reverse_association.name}").expire_association_cache(association_name)
-                  else
+                    unless send("cached_#{reverse_association.name}").nil?
+                      # cached_viewable.expire_association_cache
+                      send("cached_#{reverse_association.name}").expire_association_cache(association_name)
+                    end
+                  elsif !send("#{reverse_association.name}").nil?
                     send("#{reverse_association.name}").each do |assoc|
                       assoc.expire_association_cache(association_name)
                     end
@@ -74,8 +79,10 @@ module Cacheable
 
               define_method "expire_#{association_name}_cache" do
                 if respond_to? "cached_#{reverse_association.name}".to_sym
-                  send("cached_#{reverse_association.name}").expire_association_cache(association_name)
-                elsif not send("#{reverse_association.name}").nil?
+                  unless send("cached_#{reverse_association.name}").nil?
+                    send("cached_#{reverse_association.name}").expire_association_cache(association_name)
+                  end
+                elsif !send("#{reverse_association.name}").nil?
                   send("#{reverse_association.name}").expire_association_cache(association_name)
                 end
               end

--- a/lib/cacheable/types/association_cache.rb
+++ b/lib/cacheable/types/association_cache.rb
@@ -75,7 +75,7 @@ module Cacheable
               define_method "expire_#{association_name}_cache" do
                 if respond_to? "cached_#{reverse_association.name}".to_sym
                   send("cached_#{reverse_association.name}").expire_association_cache(association_name)
-                else
+                elsif not send("#{reverse_association.name}").nil?
                   send("#{reverse_association.name}").expire_association_cache(association_name)
                 end
               end

--- a/spec/cacheable/types/association_cache_spec.rb
+++ b/spec/cacheable/types/association_cache_spec.rb
@@ -190,6 +190,28 @@ describe Cacheable do
       user.save
     end
 
+    context "with a user" do
+      it "should not hit expire_association_cache on save" do
+        account = Account.create
+        user = User.new
+        user.expects(:expire_association_cache)
+        account.stubs(:user).returns user
+        account.save
+      end
+    end
+
+    context "without a user" do
+      it "should not hit expire_association_cache on save" do
+        account = Account.create
+        obj = mock "object"
+        obj.stubs(:nil?).returns true
+        account.stubs(:user).returns obj
+        obj.expects(:expire_association_cache).never
+        account.expire_account_cache
+      end
+
+    end
+
   end
 
 end


### PR DESCRIPTION
Issue with getting undefined method for nil class which breaks further after_commit callbacks.  Checking for nil in multiple areas of the association.
