### PR TITLE
breaking up association cache methods

### DIFF
--- a/lib/cacheable/types/association_cache.rb
+++ b/lib/cacheable/types/association_cache.rb
@@ -40,6 +40,7 @@ module Cacheable
 
       define_method("cached_#{association_name}") do
         Rails.cache.fetch belong_association_cache_key(association_name, polymorphic) do
+          association_cache.delete(association_name)
           send(association_name)
         end
       end

--- a/lib/cacheable/types/association_cache.rb
+++ b/lib/cacheable/types/association_cache.rb
@@ -22,7 +22,12 @@ module Cacheable
 
           define_method("cached_#{association_name}") do
             Rails.cache.fetch have_association_cache_key(association_name) do
-              send(association_name).respond_to?(:to_a) ? send(association_name).to_a : send(association_name)
+              association_cache.delete(association_name)
+              if send(association_name).respond_to?(:to_a)
+                send(association_name).to_a
+              else
+                send(association_name)
+              end
             end
           end
         end

--- a/lib/cacheable/types/association_cache.rb
+++ b/lib/cacheable/types/association_cache.rb
@@ -9,91 +9,108 @@ module Cacheable
         association = reflect_on_association(association_name)
 
         if :belongs_to == association.macro
-          polymorphic = association.options[:polymorphic]
-          polymorphic ||= false
-
-          define_method("cached_#{association_name}") do
-            Rails.cache.fetch belong_association_cache_key(association_name, polymorphic) do
-              send(association_name)
-            end
-          end
+          build_cache_belongs_to(association, association_name)
         else
+
           if through_reflection_name = association.options[:through]
-            through_association = self.reflect_on_association(through_reflection_name)
-
-            reverse_through_association = through_association.klass.reflect_on_all_associations(:belongs_to).detect do |assoc|
-              assoc.klass.ancestors.include?(Cacheable) && assoc.klass.reflect_on_association(association.name)
-            end
-
-            # In a through association it doesn't have to be a belongs_to
-            reverse_association = association.klass.reflect_on_all_associations(:belongs_to).find { |reverse_association|
-              reverse_association.options[:polymorphic] ? reverse_association.name == association.source_reflection.options[:as] : reverse_association.klass == self
-            }
-            if reverse_association
-              association.klass.class_eval do
-                after_commit "expire_#{association_name}_cache".to_sym
-
-                define_method("expire_#{association_name}_cache") do
-
-                  if respond_to? "expire_#{reverse_association.name}_cache".to_sym
-                    unless send("cached_#{reverse_association.name}").nil?
-                      send("cached_#{reverse_association.name}").expire_association_cache(association_name)
-                    end
-                  elsif !send(reverse_association.name).nil?
-                    if send(reverse_association.name).respond_to?(reverse_through_association.name) && !send(reverse_association.name).send(reverse_through_association.name).nil?
-                      send(reverse_association.name).send(reverse_through_association.name).expire_association_cache(association_name)
-                    end
-                  end
-                end
-              end
-            end
+            build_cache_has_through(association, association_name, through_reflection_name)
           elsif :has_and_belongs_to_many == association.macro
-              # No such thing as a polymorphic has_and_belongs_to_many
-              reverse_association = association.klass.reflect_on_all_associations(:has_and_belongs_to_many).find { |reverse_association|
-                reverse_association.klass == self
-              }
-
-              association.klass.class_eval do
-                after_commit "expire_#{association_name}_cache".to_sym
-
-                define_method "expire_#{association_name}_cache" do
-                  if respond_to? "cached_#{reverse_association.name}".to_sym
-                    unless send("cached_#{reverse_association.name}").nil?
-                      # cached_viewable.expire_association_cache
-                      send("cached_#{reverse_association.name}").expire_association_cache(association_name)
-                    end
-                  elsif !send("#{reverse_association.name}").nil?
-                    send("#{reverse_association.name}").each do |assoc|
-                      next if assoc.nil?
-                      assoc.expire_association_cache(association_name)
-                    end
-                  end
-                end
-              end
+            build_cache_has_and_belongs_to_many(association, association_name)
           else
-            reverse_association = association.klass.reflect_on_all_associations(:belongs_to).find { |reverse_association|
-              reverse_association.options[:polymorphic] ? reverse_association.name == association.options[:as] : reverse_association.klass == self
-            }
-
-            association.klass.class_eval do
-              after_commit "expire_#{association_name}_cache".to_sym
-
-              define_method "expire_#{association_name}_cache" do
-                if respond_to? "cached_#{reverse_association.name}".to_sym
-                  unless send("cached_#{reverse_association.name}").nil?
-                    send("cached_#{reverse_association.name}").expire_association_cache(association_name)
-                  end
-                elsif !send("#{reverse_association.name}").nil?
-                  send("#{reverse_association.name}").expire_association_cache(association_name)
-                end
-              end
-            end
+            build_cache_has_many(association, association_name)
           end
 
           define_method("cached_#{association_name}") do
             Rails.cache.fetch have_association_cache_key(association_name) do
               send(association_name).respond_to?(:to_a) ? send(association_name).to_a : send(association_name)
             end
+          end
+        end
+      end
+    end
+
+    def build_cache_belongs_to(association, association_name)
+      polymorphic = association.options[:polymorphic]
+      polymorphic ||= false
+
+      define_method("cached_#{association_name}") do
+        Rails.cache.fetch belong_association_cache_key(association_name, polymorphic) do
+          send(association_name)
+        end
+      end
+    end
+
+    def build_cache_has_through(association, association_name, through_reflection_name)
+      through_association = self.reflect_on_association(through_reflection_name)
+
+      reverse_through_association = through_association.klass.reflect_on_all_associations(:belongs_to).detect do |assoc|
+        assoc.klass.ancestors.include?(Cacheable) && assoc.klass.reflect_on_association(association.name)
+      end
+
+      # In a through association it doesn't have to be a belongs_to
+      reverse_association = association.klass.reflect_on_all_associations(:belongs_to).find { |reverse_association|
+        reverse_association.options[:polymorphic] ? reverse_association.name == association.source_reflection.options[:as] : reverse_association.klass == self
+      }
+      if reverse_association
+        association.klass.class_eval do
+          after_commit "expire_#{association_name}_cache".to_sym
+
+          define_method("expire_#{association_name}_cache") do
+
+            if respond_to? "expire_#{reverse_association.name}_cache".to_sym
+              unless send("cached_#{reverse_association.name}").nil?
+                send("cached_#{reverse_association.name}").expire_association_cache(association_name)
+              end
+            elsif !send(reverse_association.name).nil?
+              if send(reverse_association.name).respond_to?(reverse_through_association.name) && !send(reverse_association.name).send(reverse_through_association.name).nil?
+                send(reverse_association.name).send(reverse_through_association.name).expire_association_cache(association_name)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    def build_cache_has_and_belongs_to_many(association, association_name)
+      # No such thing as a polymorphic has_and_belongs_to_many
+      reverse_association = association.klass.reflect_on_all_associations(:has_and_belongs_to_many).find { |reverse_association|
+        reverse_association.klass == self
+      }
+
+      association.klass.class_eval do
+        after_commit "expire_#{association_name}_cache".to_sym
+
+        define_method "expire_#{association_name}_cache" do
+          if respond_to? "cached_#{reverse_association.name}".to_sym
+            unless send("cached_#{reverse_association.name}").nil?
+              # cached_viewable.expire_association_cache
+              send("cached_#{reverse_association.name}").expire_association_cache(association_name)
+            end
+          elsif !send("#{reverse_association.name}").nil?
+            send("#{reverse_association.name}").each do |assoc|
+              next if assoc.nil?
+              assoc.expire_association_cache(association_name)
+            end
+          end
+        end
+      end
+    end
+
+    def build_cache_has_many(association, association_name)
+      reverse_association = association.klass.reflect_on_all_associations(:belongs_to).find { |reverse_association|
+        reverse_association.options[:polymorphic] ? reverse_association.name == association.options[:as] : reverse_association.klass == self
+      }
+
+      association.klass.class_eval do
+        after_commit "expire_#{association_name}_cache".to_sym
+
+        define_method "expire_#{association_name}_cache" do
+          if respond_to? "cached_#{reverse_association.name}".to_sym
+            unless send("cached_#{reverse_association.name}").nil?
+              send("cached_#{reverse_association.name}").expire_association_cache(association_name)
+            end
+          elsif !send("#{reverse_association.name}").nil?
+            send("#{reverse_association.name}").expire_association_cache(association_name)
           end
         end
       end

--- a/spec/cacheable/types/association_cache_spec.rb
+++ b/spec/cacheable/types/association_cache_spec.rb
@@ -214,4 +214,13 @@ describe Cacheable do
 
   end
 
+  # https://github.com/Shopify/identity_cache/pull/55/files
+  describe "rails association cache" do
+    it "should not load associated records" do
+      user.posts
+      cached_user = User.find_cached(user.id)
+      cached_user.posts.loaded?.should be_false
+    end
+  end
+
 end


### PR DESCRIPTION
I was trying to figure out how to fix the Marshal load problem that occasionally happens when loading an object from the cache. [Shopify seems to have figured it out](https://github.com/Shopify/identity_cache/pull/55/files).  It's extremely hard to reproduce in a testing environment but I managed it in a bigger app.  Deleting the association_cache within does fix the Marshal loading problem.
