### PR TITLE
One place for association keys

### DIFF
--- a/lib/cacheable/expiry.rb
+++ b/lib/cacheable/expiry.rb
@@ -46,13 +46,14 @@ module Cacheable
     end
 
     def expire_associations_cache
-      self.class.cached_associations.each do |assoc|
-        self.expire_association_cache(assoc)
+      self.class.cached_associations.each do |name, options|
+        self.expire_association_cache(name, options)
       end
     end
 
-    def expire_association_cache(name)
-      Rails.cache.delete have_association_cache_key(name)
+    def expire_association_cache(name, options={})
+      key = association_cache_key(name, options)
+      Rails.cache.delete key unless key.nil?
     end
   end
 end

--- a/lib/cacheable/keys.rb
+++ b/lib/cacheable/keys.rb
@@ -47,8 +47,16 @@ module Cacheable
         "#{model_cache_key}/method/#{meth}"
       end
 
+      def association_cache_key(name, options={})
+        if options[:type] == :belongs_to
+          belongs_to_cache_key(name, options[:polymorphic])
+        else
+          "#{model_cache_key}/association/#{name}"
+        end
+      end
+
       # Returns nil if association cannot be qualified
-      def belong_association_cache_key(name, polymorphic=nil)
+      def belongs_to_cache_key(name, polymorphic=nil)
         name = name.to_s if name.is_a?(Symbol)
 
         if polymorphic && self.respond_to?(:"#{name}_type")
@@ -59,11 +67,7 @@ module Cacheable
         end
       end
 
-      def have_association_cache_key(name)
-        "#{model_cache_key}/association/#{name}"
-      end
-
-      # If it isa class.  It should be the base_class name
+      # If it is a class.  It should be the base_class name
       # else it should just be a name tableized
       def base_class_or_name(name)
         name = begin

--- a/lib/cacheable/types/attribute_cache.rb
+++ b/lib/cacheable/types/attribute_cache.rb
@@ -3,7 +3,7 @@ module Cacheable
     def with_attribute(*attributes)
       self.cached_indices ||= {}
       self.cached_indices = self.cached_indices.merge(attributes.each_with_object({}) {
-        |attribute, indices| indices[attribute] = {}
+        |attribute, indices| indices[attribute.to_sym] = Set.new
       })
 
       class_eval do
@@ -13,16 +13,16 @@ module Cacheable
 
       attributes.each do |attribute|
         define_singleton_method("find_cached_by_#{attribute}") do |value|
-          self.cached_indices["#{attribute}"] ||= []
-          self.cached_indices["#{attribute}"] << value
+          self.cached_indices[attribute.to_sym] ||= Set.new
+          self.cached_indices[attribute.to_sym] << value
           Cacheable.fetch(attribute_cache_key("#{attribute}", value)) do
             self.send("find_by_#{attribute}", value)
           end
         end
 
         define_singleton_method("find_cached_all_by_#{attribute}") do |value|
-          self.cached_indices["#{attribute}"] ||= []
-          self.cached_indices["#{attribute}"] << value
+          self.cached_indices[attribute.to_sym] ||= Set.new
+          self.cached_indices[attribute.to_sym] << value
           Cacheable.fetch(all_attribute_cache_key("#{attribute}", value)) do
             if Cacheable.rails4?
               self.where("#{attribute}" => value).load

--- a/lib/cacheable/types/class_method_cache.rb
+++ b/lib/cacheable/types/class_method_cache.rb
@@ -3,16 +3,19 @@ module Cacheable
     # Cached class method
     # Should expire on any instance save
     def with_class_method(*methods)
-      self.cached_class_methods = methods.each_with_object({}) { |meth, indices| indices[meth] = [] }
+      self.cached_class_methods ||= {}
+      self.cached_class_methods = self.cached_class_methods.merge(methods.each_with_object({}) {
+        |meth, indices| indices[meth.to_sym] = Set.new
+      })
 
       class_eval do
-        after_commit :expire_class_method_cache, on: :update
+        after_commit :expire_class_method_cache, :on => :update
       end
 
       methods.each do |meth|
         define_singleton_method("cached_#{meth}") do |*args|
-          self.cached_class_methods["#{meth}"] ||= []
-          self.cached_class_methods["#{meth}"] << args
+          self.cached_class_methods[meth.to_sym] ||= Set.new
+          self.cached_class_methods[meth.to_sym] << args
           Cacheable.fetch class_method_cache_key(meth, args) do
             self.method(meth).arity == 0 ? send(meth) : send(meth, *args)
           end

--- a/spec/cacheable/expiry_cache_spec.rb
+++ b/spec/cacheable/expiry_cache_spec.rb
@@ -91,7 +91,7 @@ describe Cacheable do
 
       it "should delete with_attribute cache" do
         @user = User.find_cached_by_login("flyerhzm")
-        Rails.cache.read("users/attribute/login/flyerhzm").should == {:class => @user.class, 'attributes' => @user.attributes}
+        Rails.cache.read("users/attribute/login/flyerhzm").should == coder(@user)
         @user.expire_model_cache
         Rails.cache.read("users/attribute/login/flyerhzm").should be_nil
       end
@@ -154,11 +154,6 @@ describe Cacheable do
         User.cached_indices.keys.should include :login
         User.cached_indices.keys.should_not include :email
       end
-
-      it "should have cached_methods" do
-        User.cached_methods.should_not be_nil
-        User.cached_methods.should == [:last_post, :bad_iv_name!, :bad_iv_name?, :admin?, :hash_with_class_key]
-      end
     end
 
     context "expiring class_method cache" do
@@ -180,11 +175,6 @@ describe Cacheable do
       it "has specific cached indices" do
         Descendant.cached_indices.keys.should include :login
         Descendant.cached_indices.keys.should include :email
-      end
-
-      it "should have cached_methods" do
-        Descendant.cached_methods.should_not be_nil
-        Descendant.cached_methods.should == [:last_post, :bad_iv_name!, :bad_iv_name?, :admin?, :hash_with_class_key, :name]
       end
 
       context "expiring method cache" do

--- a/spec/cacheable/keys_spec.rb
+++ b/spec/cacheable/keys_spec.rb
@@ -1,0 +1,138 @@
+require 'spec_helper'
+
+describe "Cacheable Keys" do
+
+  let(:cache) { Rails.cache }
+
+  before :all do
+    user = User.create(:login => 'scotterc')
+    user.create_account
+    post = user.posts.create
+    post.images.create
+    post.comments.create
+    Image.create
+  end
+
+  before :each do
+    @user       = User.find_by_login('scotterc')
+    @account    = @user.account
+    @image      = @user.images.first
+    @comment    = Comment.first
+    @lone_image = Image.last
+  end
+
+  describe ".attribute_cache_key" do
+    it "is key for find first by attribute" do
+      key = User.attribute_cache_key(:login, "scotterc")
+      key.should == "users/attribute/login/scotterc"
+    end
+  end
+
+  describe ".all_attribute_cache_key" do
+    it "is key for find by all" do
+      key = User.all_attribute_cache_key(:login, "scotterc")
+      key.should == "users/attribute/login/all/scotterc"
+    end
+  end
+
+  describe ".class_method_cache_key" do
+    context "without arguments" do
+      it "gives a key" do
+        key = User.class_method_cache_key(:default_name, [])
+        key.should == "users/class_method/default_name"
+      end
+    end
+
+    context "with arguments" do
+      it "gives a key" do
+        key = User.class_method_cache_key(:user_with_id, [1])
+        key.should == "users/class_method/user_with_id/1"
+      end
+    end
+  end
+
+  describe ".instance_cache_key" do
+    it "key with id param" do
+      key = User.instance_cache_key(1)
+      key.should == "users/1"
+    end
+
+    it "key with username param" do
+      key = User.instance_cache_key('scotterc')
+      key.should == "users/scotterc"
+    end
+  end
+
+  describe ".cacheable_table_name" do
+    it "base class tableized" do
+      User.cacheable_table_name.should == "users"
+    end
+  end
+
+  describe "#model_cache_keys" do
+    it "possible implementations of key lookups" do
+      value = @user.model_cache_keys
+      value.should == ["users/#{@user.id}", "users/#{@user.to_param}" ]
+    end
+  end
+
+  describe "#model_cache_key" do
+    it "base of instance key" do
+      value = @user.model_cache_key
+      value.should == "users/#{@user.id}"
+    end
+  end
+
+  describe "#method_cache_key" do
+    it "names the method" do
+      value = @user.method_cache_key(:last_post)
+      value.should == "users/1/method/last_post"
+    end
+  end
+
+  describe "#belongs_to_cache_key" do
+    it "gets the assoication" do
+      value = @account.belongs_to_cache_key(:user)
+      value.should == 'users/1'
+    end
+
+    describe "polymorphic" do
+      it "gets it" do
+        value = @image.belongs_to_cache_key(:viewable, true)
+        value.should == "posts/1"
+      end
+
+      describe "can't qualify" do
+        it "returns nil" do
+          value = @lone_image.belongs_to_cache_key(:viewable, true)
+          value.should be_nil
+        end
+      end
+    end
+  end
+
+  describe "#association_cache_key" do
+    it "uses model_cache_key and name" do
+      value = @user.association_cache_key(:account)
+      value.should == "users/1/association/account"
+    end
+
+    context "given a polymorphic name" do
+      it "should find the type" do
+        value = @comment.association_cache_key(:commentable)
+        value.should == "comments/1/association/commentable"
+      end
+    end
+  end
+
+  describe "#base_class_or_name" do
+    it "finds base class if it exists" do
+      @user.base_class_or_name("descendant").should == "users"
+    end
+
+    it "tableizes if it's not constantizable" do
+      @user.base_class_or_name("foo").should == "foos"
+    end
+  end
+
+end

--- a/spec/cacheable/model_fetch_spec.rb
+++ b/spec/cacheable/model_fetch_spec.rb
@@ -21,7 +21,7 @@ describe Cacheable do
 
   describe "association fetch" do
     it "should find associations by name" do
-      key = @user.have_association_cache_key(:posts)
+      key = @user.association_cache_key(:posts)
       Cacheable.fetch(key) do
         @user.send(:posts)
       end.should == [@post1, @post2]

--- a/spec/models/descendant.rb
+++ b/spec/models/descendant.rb
@@ -1,10 +1,8 @@
 class Descendant < User
-  belongs_to :location
 
   model_cache do
     with_attribute :email
     with_method :name
-    with_association :location
     with_class_method :default_name
   end
 

--- a/spec/models/post.rb
+++ b/spec/models/post.rb
@@ -17,7 +17,7 @@ class Post < ActiveRecord::Base
   model_cache do
     with_key
     with_attribute :user_id
-    with_association :user, :comments, :images, :tags
+    with_association :user, :comments, :images, :tags, :location
     with_class_method :retrieve_with_user_id, :retrieve_with_both, :default_post,
                       :where_options_are
   end


### PR DESCRIPTION
Store information about association in cached class info
streamline association key calling
make class caches use sets to avoid memory leak
Added specs for cache keys
Simplify name of cache key methods
change all cached information to use symbols
