### PR TITLE
Use 'camelize' instead of 'capitalize' in InstanceKeys#base_class_or_name

### DIFF
--- a/lib/cacheable/keys.rb
+++ b/lib/cacheable/keys.rb
@@ -71,7 +71,7 @@ module Cacheable
       # else it should just be a name tableized
       def base_class_or_name(name)
         name = begin
-          name.capitalize.constantize.base_class.name
+          name.camelize.constantize.base_class.name
         rescue NameError # uninitialized constant
           name
         end


### PR DESCRIPTION
Camelize properly handles underscored names. E.G. 'example_model' becomes 'ExampleModel' instead of 'Example_model'.

I ran into this error because I am trying to cache a belongs_to association with an underscore, and simple_cacheable is trying to autoload a non-existent constant.
