### PR TITLE
add a single method to override to customize cache keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,11 +48,8 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     memcached (1.7.0)
-    metaclass (0.0.1)
     mime-types (1.25.1)
     minitest (4.7.5)
-    mocha (0.10.5)
-      metaclass (~> 0.0.1)
     multi_json (1.8.4)
     polyglot (0.3.3)
     rack (1.5.2)
@@ -72,6 +69,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.1.1)
+    rr (1.1.2)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)
       rspec-expectations (~> 2.8.0)
@@ -109,7 +107,7 @@ DEPENDENCIES
   appraisal
   friendly_id
   memcached
-  mocha (= 0.10.5)
+  rr (= 1.1.2)
   rspec (= 2.8)
   simple_cacheable!
   sqlite3

--- a/README.md
+++ b/README.md
@@ -66,12 +66,26 @@ Usage
 Advanced Usage
 --------------
 
+Utilize Simple Cacheable to cache ActiveRecord objects without marshalling errors:
 ````ruby
-  # Utilize Simple Cacheable to cache ActiveRecord objects without marshalling errors
   Cacheable.fetch "collection_of_twelve_users", expires_in: 1.day do
     User.limit(12)
   end
 ````
+
+Override ````modified_cache_key```` to customize cache keys. Single point for dependency injection.
+````ruby
+  # E.G. if you wanted to version your cache:
+  class User < ActiveRecord::Base
+    has_one :cache_version
+
+    def self.modified_cache_key(key)
+      "#{cache_version.version}/#{key}"
+    end
+  end
+````
+
+(````modified_cache_key```` can be overriden at the class level or the instance level. By default the instance implementation falls back to the class implementation.)
 
 Install
 -------

--- a/cacheable.gemspec
+++ b/cacheable.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("rails", ">= 3")
   s.add_development_dependency("rspec", "2.8")
-  s.add_development_dependency("mocha", "0.10.5")
+  s.add_development_dependency("rr", "1.1.2")
   s.add_development_dependency("friendly_id")
 
   s.files         = `git ls-files`.split("\n")

--- a/gemfiles/3.2.gemfile.lock
+++ b/gemfiles/3.2.gemfile.lock
@@ -51,10 +51,7 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     memcached (1.7.0)
-    metaclass (0.0.2)
     mime-types (1.25.1)
-    mocha (0.10.5)
-      metaclass (~> 0.0.1)
     multi_json (1.8.4)
     polyglot (0.3.3)
     rack (1.4.5)
@@ -82,6 +79,7 @@ GEM
     rake (10.1.1)
     rdoc (3.12.2)
       json (~> 1.4)
+    rr (1.1.2)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)
       rspec-expectations (~> 2.8.0)
@@ -110,8 +108,8 @@ DEPENDENCIES
   appraisal
   friendly_id
   memcached
-  mocha (= 0.10.5)
   rails (~> 3.2.16)
+  rr (= 1.1.2)
   rspec (= 2.8)
   simple_cacheable!
   sqlite3

--- a/gemfiles/4.0.gemfile.lock
+++ b/gemfiles/4.0.gemfile.lock
@@ -47,11 +47,8 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     memcached (1.7.0)
-    metaclass (0.0.2)
     mime-types (1.25.1)
     minitest (4.7.5)
-    mocha (0.10.5)
-      metaclass (~> 0.0.1)
     multi_json (1.8.4)
     polyglot (0.3.3)
     rack (1.5.2)
@@ -71,6 +68,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.1.1)
+    rr (1.1.2)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)
       rspec-expectations (~> 2.8.0)
@@ -105,8 +103,8 @@ DEPENDENCIES
   appraisal
   friendly_id
   memcached
-  mocha (= 0.10.5)
   rails (~> 4.0.0)
+  rr (= 1.1.2)
   rspec (= 2.8)
   simple_cacheable!
   sqlite3

--- a/spec/cacheable/types/attribute_cache_spec.rb
+++ b/spec/cacheable/types/attribute_cache_spec.rb
@@ -25,6 +25,14 @@ describe Cacheable do
       Rails.cache.read("users/attribute/login/flyerhzm").should =={:class => @user.class, 'attributes' => @user.attributes}
     end
 
+    it "should cache by User.find_by_login with a modified key" do
+      stub(User).modified_cache_key {|key| [0, key] * '/'}
+
+      User.find_cached_by_login("flyerhzm").should == @user
+      Rails.cache.read("0/users/attribute/login/flyerhzm").should =={:class => @user.class, 'attributes' => @user.attributes}
+      Rails.cache.exist?("users/attribute/login/flyerhzm").should == false
+    end
+
     it "should get cached by User.find_by_login multiple times" do
       User.find_cached_by_login("flyerhzm")
       User.find_cached_by_login("flyerhzm").should == @user

--- a/spec/cacheable/types/class_method_cache_spec.rb
+++ b/spec/cacheable/types/class_method_cache_spec.rb
@@ -22,6 +22,14 @@ describe Cacheable do
     Rails.cache.read("posts/class_method/default_post").should == coder(@post1)
   end
 
+  it "should cache Post.default_post with modified key" do
+    stub(Post).modified_cache_key {|key| [0, key] * '/'}
+
+    Post.cached_default_post.should == @post1
+    Rails.cache.read("0/posts/class_method/default_post").should == coder(@post1)
+    Rails.cache.exist?("posts/class_method/default_post").should == false
+  end
+
   it "should cache Post.default_post multiple times" do
     Post.cached_default_post
     Post.cached_default_post.should == @post1

--- a/spec/cacheable/types/key_cache_spec.rb
+++ b/spec/cacheable/types/key_cache_spec.rb
@@ -21,6 +21,14 @@ describe Cacheable do
     Rails.cache.read("users/#{@user.id}").should == coder(@user)
   end
 
+  it "should cache by User#id with modified keys" do
+    stub(User).modified_cache_key {|key| [0, key] * '/'}
+
+    User.find_cached(@user.id).should == @user
+    Rails.cache.read("0/users/#{@user.id}").should == coder(@user)
+    Rails.cache.exist?("users/#{@user.id}").should == false
+  end
+
   it "should get cached by User#id multiple times" do
     User.find_cached(@user.id)
     User.find_cached(@user.id).should == @user

--- a/spec/cacheable/types/method_cache_spec.rb
+++ b/spec/cacheable/types/method_cache_spec.rb
@@ -20,8 +20,11 @@ describe Cacheable do
   end
 
   it "should cache User#last_post" do
+    stub(User).modified_cache_key {|key| [0, key] * '/'}
+
     @user.cached_last_post.should == @user.last_post
-    Rails.cache.read("users/#{@user.id}/method/last_post").should == coder(@user.last_post)
+    Rails.cache.read("0/users/#{@user.id}/method/last_post").should == coder(@user.last_post)
+    Rails.cache.exist?("users/#{@user.id}/method/last_post").should == false
   end
 
   it "should cache User#last_post multiple times" do
@@ -74,7 +77,7 @@ describe Cacheable do
     end
 
     it "hits the cache only once" do
-      Cacheable.expects(:fetch).returns(@user.last_post).once
+      mock(Cacheable).fetch.with_any_args { @user.last_post }.once
       @user.cached_last_post.should == @user.last_post
       @user.cached_last_post.should == @user.last_post
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'active_record'
 require 'support/ar_patches'
 require 'support/coder_macro'
 require 'rspec'
-require 'mocha/api'
+require 'rr'
 require 'memcached'
 require 'cacheable'
 require 'friendly_id'
@@ -39,7 +39,7 @@ module Rails
 end
 
 RSpec.configure do |config|
-  config.mock_with :mocha
+  config.mock_with :rr
 
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true


### PR DESCRIPTION
This commit adds a `modified_cache_key` method (on the instance and on the class level) that by default returns it's single argument unmodified. By passing all generated cache keys through this method, we expose a single point of dependency injection for cache keys. In my codebase, it's necessary sometimes to invalidate the cache for a particular model, and overriding this method to append a cache version allows for this functionality.

(On first glance `cacheable_table_name` provides this functionality, but it's used for other purposes elsewhere and is therefore unsuitable for dependency injection.)

I've omitted tests in this PR because I'm not the most experienced with RSpec and couldn't figure out a way to test this functionality without duplicating all the specs for this module. This functionality should definitely be tested and I'd welcome suggestions on how to test in a DRY manner.
